### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,40 @@
+name: Pre-Release CI
+
+on:
+  push:
+    branches:
+      - 'release-plz-*'
+
+env:
+    CARGO_TERM_COLOR: always
+    RUSTFLAGS: '-D warnings'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build with Cargo
+        run: cargo build
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Commit and Push Changes
+        run: |
+          git add .
+          git commit -m "chore: update CRD"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/ansg191/restic-operator/compare/restic-operator-v0.1.1...restic-operator-v0.1.2) - 2024-12-15
+
+### Other
+
+- Add pre-release CI
+
 ## [0.1.1](https://github.com/ansg191/restic-operator/compare/restic-operator-v0.1.0...restic-operator-v0.1.1) - 2024-12-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "restic-crd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bon",
  "k8s-openapi",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "restic-operator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bon",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "restic-operator"
 description = "Restic Operator"
 authors = ["Anshul Gupta <ansg191@anshulg.com>"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 publish = ["anshulg"]
@@ -17,7 +17,7 @@ bon = "3.3.0"
 futures = { version = "0.3.31", default-features = false, features = ["std", "async-await"] }
 k8s-openapi = { version = "0.23.0", default-features = false, features = ["v1_30"] }
 kube = { version = "0.97.0", features = ["derive", "runtime"] }
-restic-crd = { version = "0.1.0", path = "restic-crd" , registry = "anshulg" }
+restic-crd = { version = "0.1.1", path = "restic-crd" , registry = "anshulg" }
 schemars = "0.8.21"
 serde = "1.0.215"
 serde_json = "1.0.133"
@@ -30,7 +30,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [build-dependencies]
 kube = { version = "0.97.0", default-features = false }
-restic-crd = { version = "0.1.0", path = "restic-crd", registry = "anshulg" }
+restic-crd = { version = "0.1.1", path = "restic-crd", registry = "anshulg" }
 serde_yaml = "0.9.34"
 
 ### WORKSPACE ###

--- a/restic-crd/CHANGELOG.md
+++ b/restic-crd/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/ansg191/restic-operator/compare/restic-crd-v0.1.0...restic-crd-v0.1.1) - 2024-12-15
+
+### Fixed
+
+- add shortname and category to CRD definitions

--- a/restic-crd/Cargo.toml
+++ b/restic-crd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "restic-crd"
 description = "Restic Operator CRD definitions"
 authors = ["Anshul Gupta <ansg191@anshulg.com>"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 publish = ["anshulg"]


### PR DESCRIPTION
## 🤖 New release
* `restic-crd`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `restic-operator`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `restic-crd`
<blockquote>

## [0.1.1](https://github.com/ansg191/restic-operator/compare/restic-crd-v0.1.0...restic-crd-v0.1.1) - 2024-12-15

### Fixed

- add shortname and category to CRD definitions
</blockquote>

## `restic-operator`
<blockquote>

## [0.1.2](https://github.com/ansg191/restic-operator/compare/restic-operator-v0.1.1...restic-operator-v0.1.2) - 2024-12-15

### Other

- Add pre-release CI
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).